### PR TITLE
Improving error handling and fix bug in b64m_encode function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ free(buffer);
 
 ## Encoding Functions
 
-### `char *b64m_encode_std(const char *src, size_t *len)`
+### char *b64m_encode_std(const char *src, size_t *len)
 
 Encode binary data to standard Base64 format (with padding).
 
@@ -106,7 +106,7 @@ Encode binary data to standard Base64 format (with padding).
 - `ENOMEM` - Memory allocation failure
 
 
-### `char *b64m_encode_url(const char *src, size_t *len)`
+### char *b64m_encode_url(const char *src, size_t *len)
 
 Encode binary data to URL-safe Base64 format (without padding).
 
@@ -122,7 +122,7 @@ Encode binary data to URL-safe Base64 format (without padding).
 **Errors:** Same as `b64m_encode_std`
 
 
-### `size_t b64m_encode_to_buffer_std(const char *src, size_t srclen, char *dst, size_t dstlen)`
+### size_t b64m_encode_to_buffer_std(const char *src, size_t srclen, char *dst, size_t dstlen)
 
 Encode binary data to standard Base64 using user-provided buffer.
 
@@ -135,7 +135,7 @@ Encode binary data to standard Base64 using user-provided buffer.
 
 **Returns:**
 
-- Length of encoded string (excluding null terminator), or 0 on error
+- Length of encoded string (excluding null terminator), or `SIZE_MAX` on error
 
 **Errors:**
 
@@ -143,7 +143,7 @@ Encode binary data to standard Base64 using user-provided buffer.
 - `ENOSPC` - Output buffer too small
 
 
-### `size_t b64m_encode_to_buffer_url(const char *src, size_t srclen, char *dst, size_t dstlen)`
+### size_t b64m_encode_to_buffer_url(const char *src, size_t srclen, char *dst, size_t dstlen)
 
 Encode binary data to URL-safe Base64 using user-provided buffer.
 
@@ -154,7 +154,7 @@ Encode binary data to URL-safe Base64 using user-provided buffer.
 
 ## Decoding Functions
 
-### `char *b64m_decode_std(const char *src, size_t *len)`
+### char *b64m_decode_std(const char *src, size_t *len)
 
 Decode standard Base64 string to binary data.
 
@@ -173,7 +173,7 @@ Decode standard Base64 string to binary data.
 - `ENOMEM` - Memory allocation failure
 
 
-### `char *b64m_decode_url(const char *src, size_t *len)`
+### char *b64m_decode_url(const char *src, size_t *len)
 
 Decode URL-safe Base64 string to binary data.
 
@@ -182,7 +182,7 @@ Decode URL-safe Base64 string to binary data.
 **Errors:** Same as `b64m_decode_std`
 
 
-### `char *b64m_decode_mix(const char *src, size_t *len)`
+### char *b64m_decode_mix(const char *src, size_t *len)
 
 Decode mixed format Base64 (handles both standard and URL-safe).
 
@@ -191,7 +191,7 @@ Decode mixed format Base64 (handles both standard and URL-safe).
 **Errors:** Same as `b64m_decode_std`
 
 
-### `size_t b64m_decode_to_buffer_std(const char *src, size_t srclen, char *dst, size_t dstlen)`
+### size_t b64m_decode_to_buffer_std(const char *src, size_t srclen, char *dst, size_t dstlen)
 
 Decode standard Base64 string using user-provided buffer.
 
@@ -204,14 +204,15 @@ Decode standard Base64 string using user-provided buffer.
 
 **Returns:**
 
-- Length of decoded data (excluding null terminator), or 0 on error
+- Length of decoded data (excluding null terminator), or `SIZE_MAX` on error
 
 **Errors:**
+
 - `EINVAL` - Invalid arguments (NULL pointers, invalid characters, malformed padding)
 - `ENOSPC` - Output buffer too small
 
 
-### `size_t b64m_decode_to_buffer_url(const char *src, size_t srclen, char *dst, size_t dstlen)`
+### size_t b64m_decode_to_buffer_url(const char *src, size_t srclen, char *dst, size_t dstlen)
 
 Decode URL-safe Base64 string using user-provided buffer.
 
@@ -220,7 +221,7 @@ Decode URL-safe Base64 string using user-provided buffer.
 **Errors:** Same as `b64m_decode_to_buffer_std`
 
 
-### `size_t b64m_decode_to_buffer_mix(const char *src, size_t srclen, char *dst, size_t dstlen)`
+### size_t b64m_decode_to_buffer_mix(const char *src, size_t srclen, char *dst, size_t dstlen)
 
 Decode mixed format Base64 using user-provided buffer.
 
@@ -231,7 +232,7 @@ Decode mixed format Base64 using user-provided buffer.
 
 ## Utility Functions
 
-### `size_t b64m_encoded_len(size_t len)`
+### size_t b64m_encoded_len(size_t len)
 
 Calculate required buffer size for Base64 encoding.
 
@@ -245,7 +246,7 @@ Calculate required buffer size for Base64 encoding.
 
 **Note:** Always returns size for padded Base64 (standard format)
 
-### `size_t b64m_decoded_len(size_t enclen)`
+### size_t b64m_decoded_len(size_t enclen)
 
 Calculate maximum buffer size needed for Base64 decoding.
 

--- a/base64mix.h
+++ b/base64mix.h
@@ -280,7 +280,13 @@ static inline char *b64m_encode(const char *src, size_t *len,
     if ((res = malloc(buflen))) {
         // Use zero-allocation version to do the actual encoding
         // Update length with actual encoded length
-        *len = b64m_encode_to_buffer(src, *len, res, buflen, enctbl);
+        size_t outlen = b64m_encode_to_buffer(src, *len, res, buflen, enctbl);
+        if (outlen == SIZE_MAX) {
+            // Encoding failed, free buffer and return NULL
+            free(res);
+            return NULL;
+        }
+        *len = outlen;
     }
     return res;
 }

--- a/test/test_base64mix.c
+++ b/test/test_base64mix.c
@@ -874,18 +874,18 @@ static void test_encode_null_parameters(void)
     errno             = 0;
     size_t result_len = b64m_encode_to_buffer(NULL, 10, buffer, sizeof(buffer),
                                               BASE64MIX_STDENC);
-    assert(result_len == 0);
+    assert(result_len == SIZE_MAX);
     assert(errno == EINVAL);
 
     errno = 0;
     result_len =
         b64m_encode_to_buffer(data, 10, NULL, sizeof(buffer), BASE64MIX_STDENC);
-    assert(result_len == 0);
+    assert(result_len == SIZE_MAX);
     assert(errno == EINVAL);
 
     errno      = 0;
     result_len = b64m_encode_to_buffer(data, 10, buffer, sizeof(buffer), NULL);
-    assert(result_len == 0);
+    assert(result_len == SIZE_MAX);
     assert(errno == EINVAL);
 
     printf("Encode NULL parameters tests passed.\n");
@@ -906,7 +906,7 @@ static void test_encode_buffer_too_small(void)
     errno         = 0;
     size_t result = b64m_encode_to_buffer(
         data, data_len, small_buffer, sizeof(small_buffer), BASE64MIX_STDENC);
-    assert(result == 0);
+    assert(result == SIZE_MAX);
     assert(errno == ENOSPC);
 
     // Try with buffer that's just 1 byte too small
@@ -915,7 +915,7 @@ static void test_encode_buffer_too_small(void)
     errno  = 0;
     result = b64m_encode_to_buffer(data, data_len, almost_buffer,
                                    encoded_len - 1, BASE64MIX_STDENC);
-    assert(result == 0);
+    assert(result == SIZE_MAX);
     assert(errno == ENOSPC);
     free(almost_buffer);
 
@@ -1004,18 +1004,18 @@ static void test_decode_null_parameters(void)
     errno             = 0;
     size_t result_len = b64m_decode_to_buffer(NULL, 10, buffer, sizeof(buffer),
                                               BASE64MIX_STDDEC);
-    assert(result_len == 0);
+    assert(result_len == SIZE_MAX);
     assert(errno == EINVAL);
 
     errno = 0;
     result_len =
         b64m_decode_to_buffer(data, 10, NULL, sizeof(buffer), BASE64MIX_STDDEC);
-    assert(result_len == 0);
+    assert(result_len == SIZE_MAX);
     assert(errno == EINVAL);
 
     errno      = 0;
     result_len = b64m_decode_to_buffer(data, 10, buffer, sizeof(buffer), NULL);
-    assert(result_len == 0);
+    assert(result_len == SIZE_MAX);
     assert(errno == EINVAL);
 
     printf("Decode NULL parameters tests passed.\n");
@@ -1038,7 +1038,7 @@ static void test_decode_buffer_too_small(void)
     size_t result =
         b64m_decode_to_buffer(encoded, encoded_len, small_buffer,
                               sizeof(small_buffer), BASE64MIX_STDDEC);
-    assert(result == 0);
+    assert(result == SIZE_MAX);
     assert(errno == ENOSPC);
 
     // Try with buffer that's just 1 byte too small
@@ -1047,7 +1047,7 @@ static void test_decode_buffer_too_small(void)
     errno  = 0;
     result = b64m_decode_to_buffer(encoded, encoded_len, almost_buffer,
                                    required_size - 1, BASE64MIX_STDDEC);
-    assert(result == 0);
+    assert(result == SIZE_MAX);
     assert(errno == ENOSPC);
     free(almost_buffer);
 
@@ -1128,7 +1128,7 @@ static void test_decode_incomplete_groups(void)
     errno = 0;
     size_t result_len = b64m_decode_to_buffer(
         single, len, buffer, sizeof(buffer), BASE64MIX_STDDEC);
-    assert(result_len == 0 && errno == EINVAL); // Single character should be rejected (RFC 4648)
+    assert(result_len == SIZE_MAX && errno == EINVAL); // Single character should be rejected (RFC 4648)
 
     // Test 5 characters (1 incomplete group) - should return error (RFC 4648)
     const char *five = "ABCDE";
@@ -1136,7 +1136,7 @@ static void test_decode_incomplete_groups(void)
     errno = 0;
     result_len       = b64m_decode_to_buffer(five, len, buffer,
                                              sizeof(buffer), BASE64MIX_STDDEC);
-    assert(result_len == 0 && errno == EINVAL); // len % 4 == 1 should be rejected (RFC 4648)
+    assert(result_len == SIZE_MAX && errno == EINVAL); // len % 4 == 1 should be rejected (RFC 4648)
 
     // Test 9 characters (1 incomplete group) - should return error (RFC 4648)
     const char *nine = "ABCDEFGHI";
@@ -1144,7 +1144,7 @@ static void test_decode_incomplete_groups(void)
     errno = 0;
     result_len       = b64m_decode_to_buffer(nine, len, buffer,
                                              sizeof(buffer), BASE64MIX_STDDEC);
-    assert(result_len == 0 && errno == EINVAL); // len % 4 == 1 should be rejected (RFC 4648)
+    assert(result_len == SIZE_MAX && errno == EINVAL); // len % 4 == 1 should be rejected (RFC 4648)
 
     // Test with allocation version - should return NULL for len % 4 == 1 (RFC 4648)
     len                = 1;


### PR DESCRIPTION
This pull request focuses on improving error handling and documentation for Base64 encoding and decoding functions. The changes ensure consistent behavior when errors occur, replacing `0` with `SIZE_MAX` as the return value to indicate failure, and updating related documentation and tests accordingly.

### Error Handling Improvements:
* Updated all functions in `base64mix.h` to return `SIZE_MAX` instead of `0` on errors, ensuring consistent signaling of failure. This includes functions like `b64m_encode_to_buffer` and `b64m_decode_to_buffer`. [[1]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL120-R127) [[2]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL474-R492) [[3]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL499-R516) [[4]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL530-R541) [[5]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL563-R574) [[6]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL590-R607) [[7]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL618-R635)
* Adjusted logic in `b64m_encode` and `b64m_decode` to handle `SIZE_MAX` correctly, freeing allocated buffers and returning `NULL` when encoding or decoding fails. [[1]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL279-R289) [[2]](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL719-R739)

### Documentation Updates:
* Updated the README to reflect the new error handling behavior, replacing references to `0` with `SIZE_MAX` in descriptions of return values for various functions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R146) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L207-R215)
* Removed backticks from function names in the README for consistency with formatting conventions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R157)

### Testing Enhancements:
* Updated tests in `test/test_base64mix.c` to check for `SIZE_MAX` as the return value on errors, ensuring alignment with the new error handling mechanism. [[1]](diffhunk://#diff-3f339e21266da98d137d6e4b01ae79240fd85150e6b01d9c38b5b0a18bd22a5eL877-R888) [[2]](diffhunk://#diff-3f339e21266da98d137d6e4b01ae79240fd85150e6b01d9c38b5b0a18bd22a5eL909-R909) [[3]](diffhunk://#diff-3f339e21266da98d137d6e4b01ae79240fd85150e6b01d9c38b5b0a18bd22a5eL918-R918)

These changes improve the robustness and clarity of the Base64 encoding/decoding library, making error handling more intuitive and consistent across the codebase.