### PR TITLE
Remove unreachable code

### DIFF
--- a/base64mix.h
+++ b/base64mix.h
@@ -280,13 +280,9 @@ static inline char *b64m_encode(const char *src, size_t *len,
     if ((res = malloc(buflen))) {
         // Use zero-allocation version to do the actual encoding
         // Update length with actual encoded length
-        size_t outlen = b64m_encode_to_buffer(src, *len, res, buflen, enctbl);
-        if (outlen == SIZE_MAX) {
-            // Encoding failed, free buffer and return NULL
-            free(res);
-            return NULL;
-        }
-        *len = outlen;
+        // NOTE: In this case, we do not need to check for SIZE_MAX because
+        // b64m_encoded_len() already ensures that the buffer size is valid.
+        *len = b64m_encode_to_buffer(src, *len, res, buflen, enctbl);
     }
     return res;
 }


### PR DESCRIPTION
This pull request refines the `b64m_encode` function in `base64mix.h` to simplify error handling and improve code clarity. The most significant change involves removing unnecessary checks for encoding failures.

### Improvements to error handling and code clarity:

* [`base64mix.h`](diffhunk://#diff-141c7376ba822240c7ce770124d622883d6115422aa3071aa5886b560e4fa44bL283-R285): Simplified the `b64m_encode` function by removing the explicit check for `SIZE_MAX` during encoding. The function now relies on `b64m_encoded_len()` to ensure the buffer size is valid, eliminating redundant error-handling code.